### PR TITLE
fixed the removed esLint rules with new ones #6

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -71,7 +71,7 @@
     "no-caller": 2,                  // http://eslint.org/docs/rules/no-caller
     "no-div-regex": 2,               // http://eslint.org/docs/rules/no-div-regex
     "no-else-return": 2,             // http://eslint.org/docs/rules/no-else-return
-    "no-empty-label": 2,             // http://eslint.org/docs/rules/no-empty-label
+    "no-labels": 2,                  // http://eslint.org/docs/rules/no-labels
     "no-eq-null": 2,                 // http://eslint.org/docs/rules/no-eq-null
     "no-eval": 2,                    // http://eslint.org/docs/rules/no-eval
     "no-extend-native": 2,           // http://eslint.org/docs/rules/no-extend-native
@@ -139,7 +139,7 @@
     "no-lonely-if": 1,               // http://eslint.org/docs/rules/no-lonely-if
     "no-mixed-spaces-and-tabs": 1,   // http://eslint.org/docs/rules/no-mixed-spaces-and-tabs
     "no-multiple-empty-lines": [2, { // http://eslint.org/docs/rules/no-multiple-empty-lines
-      "max": 2 
+      "max": 2
       }],
     "no-nested-ternary": 2,          // http://eslint.org/docs/rules/no-nested-ternary
     "no-new-object": 2,              // http://eslint.org/docs/rules/no-new-object
@@ -153,11 +153,11 @@
       "before": false,
       "after": true
       }],
-    "space-after-keywords": 2,       // http://eslint.org/docs/rules/space-after-keywords
+    "keyword-spacing": 2,            // http://eslint.org/docs/rules/keyword-spacing
     "space-before-blocks": 2,        // http://eslint.org/docs/rules/space-before-blocks
     "space-before-function-paren": [2, "never"], // http://eslint.org/docs/rules/space-before-function-paren
     "space-infix-ops": 2,            // http://eslint.org/docs/rules/space-infix-ops
-    "space-return-throw-case": 2,    // http://eslint.org/docs/rules/space-return-throw-case
+    "keyword-spacing": 2,            // http://eslint.org/docs/rules/keyword-spacing
     "space-unary-ops": 2,            // http://eslint.org/docs/rules/space-unary-ops
     "spaced-comment": [2, "always",  {// http://eslint.org/docs/rules/spaced-comment
       "exceptions": ["-", "+"],


### PR DESCRIPTION
following rules have been changed in the .eslintrc file
1. "no-empty-label" => "no-labels"
2. "space-after-keywords" => "keyword-spacing"
3. "space-return-throw-case" => "keyword-spacing"

here is the [esLint document link](http://eslint.org/docs/rules/#removed) to the list of removed rules.
