### PR TITLE
Adjust rule space-before-function-paren

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -155,7 +155,7 @@
       }],
     "keyword-spacing": 2,            // http://eslint.org/docs/rules/keyword-spacing
     "space-before-blocks": 2,        // http://eslint.org/docs/rules/space-before-blocks
-    "space-before-function-paren": [2, "never"], // http://eslint.org/docs/rules/space-before-function-paren
+    "space-before-function-paren": [2, {"anonymous": "always", "named": "never"}], // http://eslint.org/docs/rules/space-before-function-paren
     "space-infix-ops": 2,            // http://eslint.org/docs/rules/space-infix-ops
     "space-unary-ops": 2,            // http://eslint.org/docs/rules/space-unary-ops
     "spaced-comment": [2, "always",  {// http://eslint.org/docs/rules/spaced-comment


### PR DESCRIPTION
Require space for anonymous functions

Solves #8 
