### PR TITLE
Update config to suppport eslint-plugin-react version 6.x

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -174,13 +174,13 @@
     "react/jsx-sort-prop-types": 0,  // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-sort-prop-types.md
     "react/jsx-uses-react": 2,       // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-uses-react.md
     "react/jsx-uses-vars": 2,        // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-uses-vars.md
-    "react/no-did-mount-set-state": [2, "allow-in-func"], // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-did-mount-set-state.md
+    "react/no-did-mount-set-state": 2, // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-did-mount-set-state.md
     "react/no-did-update-set-state": 2, // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-did-update-set-state.md
     "react/no-multi-comp": 2,        // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-multi-comp.md
     "react/no-unknown-property": 2,  // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-unknown-property.md
     "react/prop-types": 2,           // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/prop-types.md
     "react/react-in-jsx-scope": 2,   // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/react-in-jsx-scope.md
     "react/self-closing-comp": 2,    // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/self-closing-comp.md
-    "react/wrap-multilines": 2      // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/wrap-multilines.md
+    "react/jsx-wrap-multilines": 2   // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-wrap-multilines.md
   }
 }


### PR DESCRIPTION
eslint-plugin-react had a major version update recently and it broke the setup
instructions for the plugin because the rules in this repository are no longer
compatible.

In particular:
- The allow-in-func setting for no-did-mount-set-state was removed, since it's
  now the default.
- The wrap-multilines rule was renamed to jsx-wrap-multilines. This resulted in
  a warning.

To test this change, I made a simple project with an .eslintrc that just
includes this plugin, and I followed the steps in the README. Without doing
anything special, it broke when I ran eslint, and after `npm link`ing this
change, it works.

Note that I think this breaks this plugin when used against eslint-plugin-react
versions prior to 6.0.0. I imagine this kind of problem could be avoided using
peer dependencies like eslint-config-airbnb does. In the meantime, this change
seems reasonable because probably people will be updating all lint-related
dependencies at once anyway.
