### PR TITLE
Support eslint 4

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,7 +1,9 @@
 /* Based on https://github.com/FreeCodeCamp/freecodecamp/blob/staging/.eslintrc */
 {
-  "ecmaFeatures": {
-    "jsx": true
+  "parserOptions": {
+    "ecmaFeatures": {
+      "jsx": true
+      }
     },
   "env": {                           // http://eslint.org/docs/user-guide/configuring.html#specifying-environments
     "browser": true,                 // browser global variables


### PR DESCRIPTION
The ecmaVersion option moved into parserOptions in eslint 2, but in eslint 4 it will cause an error at the top level.