### PR TITLE
FIx doc url

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,6 @@ This package provides an Unofficial Airbnb ESLint config, following their ES5 st
 You may need to install the package globally for it to be found by the parser if you have ESLint installed globally.
 - `npm install -g eslint-config-airbnb-es5`
 
-See [Airbnb's ES5 Javascript styleguide](https://github.com/airbnb/javascript/tree/master/es5) and
+See [Airbnb's ES5 Javascript styleguide](https://github.com/airbnb/javascript/tree/es5-deprecated/es5) and
 the [ESlint config docs](http://eslint.org/docs/user-guide/configuring#extending-configuration-files)
 for more information.


### PR DESCRIPTION
See [Airbnb's ES5 Javascript styleguide](https://github.com/airbnb/javascript/tree/master/es5) and

replaced to:

See [Airbnb's ES5 Javascript styleguide](https://github.com/airbnb/javascript/tree/es5-deprecated/es5) and